### PR TITLE
Phasemodel refactor

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -153,7 +153,7 @@ version = "4.1.1"
 
 [[deps.CrystalShift]]
 deps = ["BackgroundSubtraction", "CSV", "CovarianceFunctions", "DataFrames", "JSON", "LinearAlgebra", "NPZ", "OptimizationAlgorithms", "ProgressBars", "Random", "SpecialFunctions", "Test"]
-git-tree-sha1 = "ccf286143062c5c6c558b007a3b78778877a8267"
+git-tree-sha1 = "4fcf6989e3e0ebc6dcde8b144f4546acc6eb25b2"
 repo-rev = "main"
 repo-url = "https://github.com/MingChiangChang/CrystalShift.jl"
 uuid = "fb120844-f04e-4a6b-a6eb-278194263097"

--- a/script/AlFeLiO.jl
+++ b/script/AlFeLiO.jl
@@ -55,10 +55,10 @@ for y in ProgressBar(eachcol(data.I[:,1:1]))
     prob = zeros(num_nodes)
 
     for i in 1:num_nodes
-        θ = get_free_params(result[i].current_phases)
-        orig = [p.origin_cl for p in result[i].current_phases]
-        # reconstruction[:, i] = reconstruct!(result[i].current_phases, θ, x, zero(x))
-        full_mean_θ, full_std_θ = extend_priors(mean_θ, std_θ, result[i].current_phases)
+        θ = get_free_params(result[i].phase_model)
+        orig = [p.origin_cl for p in result[i].phase_model]
+        # reconstruction[:, i] = reconstruct!(result[i].phase_model, θ, x, zero(x))
+        full_mean_θ, full_std_θ = extend_priors(mean_θ, std_θ, result[i].phase_model)
         # num_of_params[i] = length(θ)
         prob[i] = approximate_negative_log_evidence(result[i], θ, x, y, std_noise, full_mean_θ, full_std_θ, objective, true)
         # residual_norm[i] = norm(y - reconstruction[:, i])

--- a/script/Full_TaSnO.jl
+++ b/script/Full_TaSnO.jl
@@ -98,16 +98,16 @@ for i in tqdm(1:size(data, 1)) # size(data, 1)
         # display(plt)
 
         # print(result_node)
-        # for p in result_node.current_phases
+        # for p in result_node.phase_model
         #     println(p)
         # end
 
         plt = plot(q[i,:], new, xtickfontsize=10, ytickfontsize=10, lw=4, label="Diffraction")
         n = ""
-        # for p in result_node.current_phases
+        # for p in result_node.phase_model
         #     n = n * p.name * "\n"
         # end
-        for p in result_node.current_phases
+        for p in result_node.phase_model
             plot!(q[i, :], p.(q[i, :]), label=p.name, ylims=(0.0, 1.0), lw=2)
         end
         title!("$(condition) $(j)")
@@ -116,7 +116,7 @@ for i in tqdm(1:size(data, 1)) # size(data, 1)
         savefig("figures/$(condition) $(j).png")
 
         stripe[j] =  [ PhaseResult(p.cl, p.name, BH[j, :], new, isCenter[j])
-                      for p in result_node.current_phases]
+                      for p in result_node.phase_model]
     end
     subdf = df[(df.xcenter .== conds[i][1]) .& (df.ycenter .== conds[i][2]), :]
     local ta = subdf[!, "Ta.nmol_offgrid"]

--- a/src/CrystalTree.jl
+++ b/src/CrystalTree.jl
@@ -2,6 +2,10 @@ module CrystalTree
 using ForwardDiff
 using CrystalShift
 using CrystalShift: CrystalPhase, optimize!, _residual!, _prior, kl
+using CrystalShift: PhaseModel, get_param_nums
+
+import CrystalShift: get_phase_ids
+
 using LazyInverses
 using OptimizationAlgorithms
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -33,7 +33,7 @@ function Node(node::Node, phases::AbstractVector{<:CrystalPhase},
 	          x::AbstractVector, y::AbstractVector, isOptimized::Bool = true)
     check_same_phase(node, phases) || error("Phases must be the same as in the node")
     recon = phases.(x)
-	Node(node.current_phases, node.child_node, node.id, 
+	Node(phases, node.child_node, node.id, 
 	     recon, y.-recon, cos_angle(recon, y), isOptimized)
 end
 

--- a/src/node.jl
+++ b/src/node.jl
@@ -1,9 +1,9 @@
 # Do breadth-first-search
 # Recursive?
 
-struct Node{T, CP<:AbstractVector{T}, CN<:AbstractVector,
+struct Node{PM<:PhaseModel, CN<:AbstractVector,
 	        R<:AbstractVector, K<:AbstractVector, I<:Real}
-	current_phases::CP
+	phase_model::PM
 	child_node::CN
 
 	id::Int
@@ -13,21 +13,30 @@ struct Node{T, CP<:AbstractVector{T}, CN<:AbstractVector,
 	is_optimized::Bool
 end
 
+# TODO: allow PM() to create empty phasemodel object
+Node() = Node(PhaseModel(), Node[], 1, Float64[], Float64[], 0., false) # Root
+Node(CP::CrystalPhase, id::Int) = Node(PhaseModel(CP), Node[], id, Float64[], Float64[], 0., false)
+Node(CPs::AbstractVector{<:CrystalPhase}, id::Int) = Node(PhaseModel(CPs), Node[], id, Float64[], Float64[], 0., false)
 
-Node{T}() where {T<:CrystalPhase} = Node(T[], Node{<:T}[], 1, Float64[], Float64[], 0., false) # Root
-Node(CP::CrystalPhase, id::Int) = Node([CP], Node{<:CrystalPhase}[], id, Float64[], Float64[], 0., false)
-Node(CPs::AbstractVector{<:CrystalPhase}, id::Int) = Node(CPs, Node{<:CrystalPhase}[], id, Float64[], Float64[], 0., false)
+# TODO: Include background into PhaseModel
+# function Node(CPs::AbstractVector{<:CrystalPhase},
+# 	          child_nodes::AbstractVector,
+# 			  x::AbstractVector, y::AbstractVector, id::Int) 
+# 	recon = CPs.(x)
+#     Node(CPs, child_nodes, id, recon, y.-recon, cos_angle(y, recon), false)
+# end
 
-function Node(CPs::AbstractVector{<:CrystalPhase},
-	          child_nodes::AbstractVector,
-			  x::AbstractVector, y::AbstractVector, id::Int) 
-	recon = CPs.(x)
-    Node(CPs, child_nodes, id, recon, y.-recon, cos_angle(y, recon), false)
+function Node(PM::PhaseModel, child_nodes::AbstractVector,
+	          x::AbstractVector, y::AbstractVector)
+    recon = PM(x)
+	Node(CPs, child_nodes, id, recon, y.-recon, cos_angle(y, recon), false)
 end
 
 
-Base.getindex(n::Node, i::Int) = Base.getindex(n.current_phases, i)
+Base.getindex(n::Node, i::Int) = Base.getindex(n.phase_model, i)
 Base.getindex(n::Node, I::Vector{Int}) = [n[i] for i in I]
+get_phase_ids(n::Node) = get_phase_ids(n.phase_model)
+
 
 function Node(node::Node, phases::AbstractVector{<:CrystalPhase},
 	          x::AbstractVector, y::AbstractVector, isOptimized::Bool = true)
@@ -37,8 +46,33 @@ function Node(node::Node, phases::AbstractVector{<:CrystalPhase},
 	     recon, y.-recon, cos_angle(recon, y), isOptimized)
 end
 
+function Node(node::Node, PM::PhaseModel,
+			x::AbstractVector, y::AbstractVector, isOptimized::Bool = true)
+	check_same_phase(node, PM) || error("Phases must be the same as in the node")
+	recon = PM(x)
+	Node(PM, node.child_node, node.id, 
+	     recon, y.-recon, cos_angle(recon, y), isOptimized)
+end
+
 function check_same_phase(node::Node, phases::AbstractVector{<:CrystalPhase})
-	check_same_phase(node.current_phases, phases)
+	check_same_phase(node.phase_model, phases)
+end
+
+function check_same_phase(node::Node, PM::PhaseModel)
+	check_same_phase(node.phase_model, PM)
+end
+
+function check_same_phase(PM1::PhaseModel, PM2::PhaseModel)
+	check_same_phase(PM1.CPs, PM2.CPs)
+end
+function check_same_phase(PM::PhaseModel, 
+	                      phase_comb::AbstractVector{<:CrystalPhase})
+	check_same_phase(PM.CPs, phase_comb)
+end
+
+function check_same_phase(phase_comb::AbstractVector{<:CrystalPhase}, 
+	                      PM::PhaseModel)
+    check_same_phase(PM.CPs, phase_comb)
 end
 
 function check_same_phase(phase_comb1::AbstractVector{<:CrystalPhase}, 
@@ -55,7 +89,7 @@ end
 function Base.show(io::IO, node::Node)
 	println("Node ID: $(node.id)")
     println("Phases:")
-	for phase in node.current_phases
+	for phase in node.phase_model
 		println("    $(phase.name)")
 	end
 	println("Number of child nodes: $(size(node.child_node))")
@@ -69,12 +103,12 @@ function Base.show(io::IO, node::Node)
 end
 
 function Base.:(==)(a::Node, b::Node)
-    return [p.id for p in a.current_phases] == [p.id for p in b.current_phases]
+    return a.phase_model == b.phase_model
 end
 
 function is_child(parent::Node, child::Node)
-	return issubset([p.id for p in parent.current_phases],
-	               [p.id for p in child.current_phases])
+	return issubset([p.id for p in parent.phase_model],
+	               [p.id for p in child.phase_model])
 end
 
 function get_child_node_indicies(parent::Node, l_nodes)
@@ -88,8 +122,8 @@ function get_child_node_indicies(parent::Node, l_nodes)
 end
 
 function is_immidiate_child(parent::Node, child::Node)
-    return (issubset([p.id for p in parent.current_phases],
-	         [p.id for p in child.current_phases]) &&
+    return (issubset([p.id for p in parent.phase_model],
+	         [p.id for p in child.phase_model]) &&
 			  (get_level(parent)-get_level(child) == -1))
 end
 
@@ -105,8 +139,8 @@ function remove_child!(parent::Node, child::Node)
 	end
 end
 
-get_level(node::Node) = size(node.current_phases)[1]
-get_phase_ids(node::Node) = [p.id for p in node.current_phases]
+get_level(node::Node) = size(node.phase_model)[1]
+get_phase_ids(node::Node) = [p.id for p in node.phase_model]
 get_inner(nodes::AbstractVector{<:Node}) = [node.inner for node in nodes]
 get_child_ids(node::Node) = [node.child_node[i].id for i in eachindex(node.child_node)]
 get_ids(nodes::AbstractVector{<:Node}) = [node.id for node in nodes]
@@ -146,18 +180,18 @@ function get_node_with_exact_ids(nodes::AbstractVector, ids::AbstractVector)
 	end
 end
 
-(node::Node)(x::AbstractVector) = node.current_phases.(x)
+(node::Node)(x::AbstractVector) = node.phase_model(x)
 cos_angle(node::Node, x::AbstractVector) = cos_angle(node(x), x)
 
 
 function fit!(node::Node, x::AbstractVector, y::AbstractVector,
 	std_noise::Real, mean::AbstractVector, std::AbstractVector,
 	maxiter=32, regularization::Bool=true)
-    optimized_phases, residuals = fit_phases(node.current_phases, x, y,
+    optimized_phases, residuals = fit_phases(node.phase_model, x, y,
 									std_noise, mean, std,
 									maxiter=maxiter,
 									regularization=regularization)
-    node.current_phases = optimized_phases
+    node.phase_model = optimized_phases
 	return residuals
 end
 
@@ -180,7 +214,7 @@ function residual(node::Node, θ::AbstractVector,
 	              x::AbstractVector, y::AbstractVector)
 	residual = copy(y)
 
-	for phase in node.current_phases
+	for phase in node.phase_model
 	    full_θ = get_eight_params(phase, θ)
 	    residual .-= CrystalPhase(phase, θ).(x)
 		plot!(x, residual)
@@ -191,7 +225,7 @@ end
 
 # function residual(node::Node, x::AbstractVector, y::AbstractVector)
 # 	θ = Float64[]
-#     for phase in node.current_phases
+#     for phase in node.phase_model
 # 		θ = [θ; get_free_params(phase)]
 # 	end
 #     residual(node, θ, x, y)

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -13,11 +13,15 @@ struct Tree{T, CP<:AbstractVector{T}, DP<:Int}
     depth::DP # Store for convenience
 end
 
+# function Tree(phases::AbstractVector{<:CrystalPhase}, depth::Int;
+# 	         x::AbstractVector=[], include_background::Bool=false)
+    
+# end
+
 function Tree(phases::AbstractVector{<:CrystalPhase}, depth::Int)
     # Construct tree with certain depth
-	T = eltype(phases)
-    nodes = Node{<:T}[]
-	root = Node{T}()
+    nodes = Node[]
+	root = Node()
 	push!(nodes, root)
 
 	id = 2

--- a/test/debug.jl
+++ b/test/debug.jl
@@ -30,7 +30,7 @@ tree = Tree(cs[1:15], 3)
 x = collect(8:.035:45)
 y = zero(x)
 @time for node in tree.nodes[2:3]
-    node.current_phases(x, y)
+    node.phase_model(x, y)
 end
 
 y ./= maximum(y)
@@ -38,11 +38,11 @@ y ./= maximum(y)
 idx, n = get_node_with_exact_ids(tree.nodes, [0, 1, 9])
 # optimize one phase and do detail residual gradient tests
 
-result = optimize!(n[1].current_phases, x, y, std_noise,
+result = optimize!(n[1].phase_model, x, y, std_noise,
           mean_θ, std_θ, maxiter=256, regularization=true)
 
-orig = [p.origin_cl for p in n[1].current_phases]
-θ = get_parameters(n[1].current_phases)
+orig = [p.origin_cl for p in n[1].phase_model]
+θ = get_parameters(n[1].phase_model)
 full_mean_θ, full_std_θ = extend_priors(mean_θ, std_θ, orig)
 test_y = convert(Vector{Real}, y)
 hessian_of_objective(n[1], θ, x, test_y, std_noise, full_mean_θ, full_std_θ)
@@ -50,11 +50,11 @@ log_marginal_likelihood(n[1], θ, x, test_y, std_noise, full_mean_θ, full_std_�
 
 # idx, n2 = get_node_with_exact_ids(tree.nodes, [0])
 
-# result2 = optimize!(n2[1].current_phases, x, y, std_noise,
+# result2 = optimize!(n2[1].phase_model, x, y, std_noise,
 #           mean_θ, std_θ, maxiter=1000, regularization=true)
 
-# orig = [p.origin_cl for p in n2[1].current_phases]
-# θ = get_parameters(n2[1].current_phases)
+# orig = [p.origin_cl for p in n2[1].phase_model]
+# θ = get_parameters(n2[1].phase_model)
 # full_mean_θ, full_std_θ = extend_priors(mean_θ, std_θ, orig)
 # test_y = convert(Vector{Real}, y)
 # hessian_of_objective(n2[1], θ, x, test_y, std_noise, full_mean_θ, full_std_θ)

--- a/test/node.jl
+++ b/test/node.jl
@@ -25,7 +25,7 @@ cs = Vector{CrystalPhase}(undef, size(s))
 println("$(size(cs, 1)) phase objects created!")
 
 # Creating objects for testing
-root = Node{CrystalPhase}()
+root = Node()
 node1 = Node(cs[1], 2)
 node2 = Node([cs[1], cs[2]], 3)
 node3 = Node([cs[1], cs[2]], 4)

--- a/test/probabilistic.jl
+++ b/test/probabilistic.jl
@@ -1,4 +1,4 @@
-module Testprobabilitic
+module Testprobabilistic
 using Test
 using CrystalTree
 using CrystalTree: approximate_negative_log_evidence
@@ -37,7 +37,7 @@ x = collect(8:.035:45)
 y = zero(x)
 
 for node in tree.nodes[2:3]
-    node.current_phases(x, y)
+    node.phase_model(x, y)
 end
 
 noise = rand(size(x, 1))
@@ -55,9 +55,9 @@ num_nodes = find_first_unassigned(result) - 1
 
 prob = zeros(num_nodes)
 for i in 1:num_nodes
-    θ = get_free_params(result[i].current_phases)
-    # orig = [p.origin_cl for p in result[i].current_phases]
-    full_mean_θ, full_std_θ = extend_priors(mean_θ, std_θ, result[i].current_phases)
+    θ = get_free_params(result[i].phase_model)
+    # orig = [p.origin_cl for p in result[i].phase_model]
+    full_mean_θ, full_std_θ = extend_priors(mean_θ, std_θ, result[i].phase_model.CPs)
     prob[i] = approximate_negative_log_evidence(result[i], θ, x, y, std_noise, full_mean_θ, full_std_θ, objective)
 end
 
@@ -67,5 +67,5 @@ true_phase_ids = Set([0,1])
 phase_ids = Set(get_phase_ids(result[i_min]))
 @test phase_ids == true_phase_ids
 
-end # Testprobabilitic module
+end # Testprobabilistic module
 

--- a/test/search.jl
+++ b/test/search.jl
@@ -1,7 +1,7 @@
 module Testsearch
 using CrystalTree
 using CrystalTree: bestfirstsearch, res_bfs, find_first_unassigned
-using CrystalTree: get_all_child_node_ids, get_ids, get_all_child_node
+using CrystalTree: get_all_child_node_ids, get_ids, get_all_child_node, get_phase_ids
 using Test
 using CrystalShift
 using CrystalShift: CrystalPhase, optimize!, Lorentz
@@ -34,7 +34,7 @@ tree = Tree(cs[1:15], 3)
 x = collect(8:.035:45)
 y = zero(x)
 for node in tree.nodes[2:3]
-    node.current_phases(x, y)
+    node.phase_model(x, y)
 end
 
 
@@ -44,7 +44,7 @@ result = bestfirstsearch(tree, x, y, std_noise, mean_θ, std_θ, 10,
                         maxiter=64, regularization=true) # should return a bunch of node
 ind = find_first_unassigned(result) - 1
 min_node = argmin([norm(result[i](x).-y) for i in eachindex(result[1:ind])])
-@test Set([result[min_node].current_phases[i].id for i in eachindex(result[min_node].current_phases)]) == Set([1,2])
+@test Set(get_phase_ids(result[min_node])) == Set([1,2])
 
 result = res_bfs(tree, x, y, std_noise, mean_θ, std_θ, 10,
                         maxiter=1000, regularization=true) # should return a bunch of node
@@ -61,6 +61,6 @@ last_ind = find_first_unassigned(result) - 1
 
 res = [norm(result[i](x).-y) for i in 1:last_ind]
 ind = argmin(res)
-@test Set([result[ind].current_phases[i].id for i in eachindex(result[ind].current_phases)]) == Set([0, 1]) 
+@test Set(get_phase_ids(result[ind])) == Set([0, 1]) 
 
 end # module

--- a/test/tree.jl
+++ b/test/tree.jl
@@ -1,6 +1,6 @@
 module Testtree
 using CrystalTree
-using CrystalTree: search!, bft, pos_res_thresholding, get_level
+using CrystalTree: search!, bft, pos_res_thresholding, get_level, get_phase_ids
 using DelimitedFiles
 using LinearAlgebra
 using Test
@@ -52,7 +52,7 @@ residual = Float64[]
 ind = argmin([norm(i(x)-y) for i in res])
 
 @testset "Basic tree search with trimming" begin
-    @test Set([res[ind].current_phases[i].id for i in eachindex(res[ind].current_phases)]) == Set([1, 2]) 
+    @test Set(get_phase_ids(res[ind])) == Set([1, 2]) 
 end
 
 end # module


### PR DESCRIPTION
This PR updates

-  all of the function that takes `AbstractVector{CrystalPhase}` to be able to take `PhaseModel` as input instead.
- search and probabilistic methods to work with `PhaseModel` and potentially background parameters
- some helper functions e.g. get_phase_ids
